### PR TITLE
Add mjs exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "React hook for remembering previous value.",
   "main": "./dist/use-previous.cjs.js",
   "module": "./dist/use-previous.esm.js",
+  "exports": {
+    ".": {
+      "require": "./dist/use-previous.cjs.js",
+      "import": "./dist/use-previous.mjs"
+    }
+  },
   "types": "./types/index.d.ts",
   "files": [
     "dist",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ export default {
   output: [
     { file: pkg.main, format: 'cjs', exports: 'named' },
     { file: pkg.module, format: 'esm' },
+    { file: pkg.exports['.'].import, format: 'esm' },
   ],
   external: [
     ...Object.keys(pkg.dependencies || {}),


### PR DESCRIPTION
Importing this module in nodejs from an `esm` module will not work as expected

```js
> await import("use-previous")
[Module: null prototype] {
  __esModule: true,
  default: { default: [Function: usePrevious] }
}
```

This PR fixes the behavior by making `usePrevious` a default export.
Thanks!